### PR TITLE
15 optimize move ordering

### DIFF
--- a/src/board.c
+++ b/src/board.c
@@ -41,11 +41,6 @@ static void prng_init(void) {
 int load_position(char* fen) {
 	ASSERT(fen);
 
-	/*
-	for (int i = 0; i < 12; i++)
-		bitboards[i] = 0u;
-		*/
-
 	for (int i = 0; i < 16; i++)
 		material_counts[i] = 0;
 
@@ -105,7 +100,7 @@ int load_position(char* fen) {
 				p = EMPTY;
 				int num_empty_sq = fen[pos] - '0';
 				for (int i = 0; i < num_empty_sq; i++) {
-					board2[10 * (y + 2) + x + 1] = 0;
+					board[10 * (y + 2) + x + 1] = 0;
 					x++;
 				}
 		}
@@ -114,14 +109,10 @@ int load_position(char* fen) {
 			int addr = 10 * (y + 2) + x + 1;
 			if (!on_board(addr)) return 1;
 
-			board2[addr] = p;
+			board[addr] = p;
 			++material_counts[p];
+			piece_addr[p][material_counts[p] - 1] = addr;
 			hash_piece(p, addr);
-
-			if (p == WKING)
-				wking_addr = addr;
-			else if (p == BKING)
-				bking_addr = addr;
 
 			x++;
 		}
@@ -201,9 +192,6 @@ int load_position(char* fen) {
 	history[0] = game_hash;
 	history_cnt = 1;
 
-	ASSERT(on_board(wking_addr));
-	ASSERT(on_board(bking_addr));
-
 	return 0;
 }
 
@@ -212,23 +200,14 @@ void init(void) {
 	// init offboard
 	for (int i = 0; i < 120; i++) {
 		if (i < 21 || i > 98 || i % 10 == 0 || i % 10 == 9) {
-			board2[i] = OFF_BOARD;
+			board[i] = OFF_BOARD;
 		}
 	}
-
-	// init bitboards
-	/*
-	for (int i = 0; i < 12; i++)
-		bitboards[i] = 0u;
-		*/
 
 	prng_init();
 	for (int i = 0; i < NUM_ZOBRIST_KEYS; i++) {
 		zobrist_keys[i] = prng();
 	}
-
-	wking_addr = -1;
-	bking_addr = -1;
 
 	uci_cmd_received = 0;
 	uci_pos_loaded = 0;

--- a/src/core.h
+++ b/src/core.h
@@ -105,14 +105,18 @@ typedef struct {
  * Each address contains a bitfield of the where the rightmost bit is color
  * (0 = white, 1 = black) and the next 3 bits determine piece type. 
  * Use macros to extract info. */
-unsigned int board2[120];
+unsigned int board[120];
 
-PIECE material_counts[16];	// count of each piece type
+/* Addresses of each piece on the board
+ * The first four arrays are EMPTY, UNUSED, OFFBOARD, UNUSED
+ * so that macros can be used directly.
+ * piece_addr does not get initiliazed because access is 
+ * based on material counts.*/
+int piece_addr[16][10];
+int material_counts[16];	// count of each piece type
 				// use 16 indices so PIECE macros
 				// can be used directly to index array
 
-int wking_addr;
-int bking_addr;
 COLOR side_to_move;		// 1 = black, 0 = white
 int halfmoves;			// halfmoves since last capture or pawn advance
 int moves;			// fullmove counter

--- a/src/engine.c
+++ b/src/engine.c
@@ -189,8 +189,9 @@ void engine_send_uci_command(const char* cmd) {
 			return;
 
 			// non standard testing command
-		} else if (!uci_search_active && next_token_eq(cmd, "perftsuite")) {
+		} else if (!uci_search_active && next_token_eq(cmd, "testsuite")) {
 
+			hash_check();
 			perft_test(5);
 			return;
 

--- a/src/eval.c
+++ b/src/eval.c
@@ -181,27 +181,27 @@ int* eg_piece_tables[6] = {
 static int wp_mobility(int a) {
 	int n_moves = 0;
 
-	ASSERT(board2[a] == WPAWN);
+	ASSERT(board[a] == WPAWN);
 	ASSERT(addr_to_rank(a) <= 7);
 	ASSERT(on_board(a - 10));
 
 	// advance
-	if (board2[a - 10] == EMPTY) {
+	if (board[a - 10] == EMPTY) {
 		n_moves++;
 		if (addr_to_rank(a) == 7)
 			n_moves += 3;
-		if (addr_to_rank(a) == 2 && board2[a - 20] == EMPTY) {
+		if (addr_to_rank(a) == 2 && board[a - 20] == EMPTY) {
 			n_moves++;
 		}
 	}
 	// captures
-	PIECE tp = board2[a - 9];
+	PIECE tp = board[a - 9];
 	if (check_color(tp, BLACK) || ep_addr == a - 9) {
 		n_moves++;
 		if (addr_to_rank(a) == 7)
 			n_moves += 3;
 	}
-	tp = board2[a - 11];
+	tp = board[a - 11];
 	if (check_color(tp, BLACK) || ep_addr == a - 11) {
 		n_moves++;
 		if (addr_to_rank(a) == 7)
@@ -214,27 +214,27 @@ static int wp_mobility(int a) {
 static int bp_mobility(int a) {
 	int n_moves = 0;
 
-	ASSERT(board2[a] == BPAWN);
+	ASSERT(board[a] == BPAWN);
 	ASSERT(addr_to_rank(a) <= 7);
 	ASSERT(on_board(a + 10));
 
 	// advance
-	if (board2[a + 10] == EMPTY) {
+	if (board[a + 10] == EMPTY) {
 		n_moves++;
 		if (addr_to_rank(a) == 2)
 			n_moves += 3;
-		if (addr_to_rank(a) == 7 && board2[a + 20] == EMPTY) {
+		if (addr_to_rank(a) == 7 && board[a + 20] == EMPTY) {
 			n_moves++;
 		}
 	}
 	// captures
-	PIECE tp = board2[a + 9];
+	PIECE tp = board[a + 9];
 	if (check_color(tp, WHITE) || ep_addr == a + 9) {
 		if (addr_to_rank(a) == 2)
 			n_moves += 3;
 		n_moves++;
 	}
-	tp = board2[a + 11];
+	tp = board[a + 11];
 	if (check_color(tp, WHITE) || ep_addr == a + 11) {
 		if (addr_to_rank(a) == 2)
 			n_moves += 3;
@@ -250,14 +250,14 @@ static int bp_mobility(int a) {
 // Target is valid if it is empty or not color c
 // TODO There is an identical function in move_gen.c
 static int is_valid_target(int ta, COLOR c) {
-	PIECE p = board2[ta];
+	PIECE p = board[ta];
 	return (p != OFF_BOARD) && (!check_color(p, c) || p == EMPTY);
 }
 
 // calculate number of pseudo legal knight moves for a knight at address a
 static int knight_mobility(int a) {
-	ASSERT(board2[a] == WKNIGHT || board2[a] == BKNIGHT);
-	COLOR c = CMASK & board2[a];
+	ASSERT(board[a] == WKNIGHT || board[a] == BKNIGHT);
+	COLOR c = CMASK & board[a];
 
 	int n_moves = 0;
 	if (is_valid_target(a - 21, c))
@@ -281,8 +281,8 @@ static int knight_mobility(int a) {
 
 // calculate number of pseudo legal moves for a king at address a
 static int king_mobility(int a) {
-	ASSERT(board2[a] == WKING || board2[a] == BKING);
-	COLOR c = board2[a] & CMASK;
+	ASSERT(board[a] == WKING || board[a] == BKING);
+	COLOR c = board[a] & CMASK;
 
 	int n_moves = 0;
 
@@ -305,34 +305,34 @@ static int king_mobility(int a) {
 
 	if (c == WHITE) {
 		if (		castle_rights & K_CASTLE && 
-				board2[a + 1] == EMPTY && 
-				board2[a + 2] == EMPTY) {
-			ASSERT(board2[98] == WROOK);
-			ASSERT(board2[95] == WKING);
+				board[a + 1] == EMPTY && 
+				board[a + 2] == EMPTY) {
+			ASSERT(board[98] == WROOK);
+			ASSERT(board[95] == WKING);
 			n_moves++;
 		}
 		if (		castle_rights & Q_CASTLE && 
-				board2[a - 1] == EMPTY && 
-				board2[a - 2] == EMPTY && 
-				board2[a - 3] == EMPTY) {
-			ASSERT(board2[91] == WROOK);
-			ASSERT(board2[95] == WKING);
+				board[a - 1] == EMPTY && 
+				board[a - 2] == EMPTY && 
+				board[a - 3] == EMPTY) {
+			ASSERT(board[91] == WROOK);
+			ASSERT(board[95] == WKING);
 			n_moves++;
 		}
 	} else {
 		if (		castle_rights & k_CASTLE && 
-				board2[a + 1] == EMPTY && 
-				board2[a + 2] == EMPTY) {
-			ASSERT(board2[28] == BROOK);
-			ASSERT(board2[25] == BKING);
+				board[a + 1] == EMPTY && 
+				board[a + 2] == EMPTY) {
+			ASSERT(board[28] == BROOK);
+			ASSERT(board[25] == BKING);
 			n_moves++;
 		}
 		if (		castle_rights & q_CASTLE && 
-				board2[a - 1] == EMPTY && 
-				board2[a - 2] == EMPTY && 
-				board2[a - 3] == EMPTY) {
-			ASSERT(board2[21] == BROOK);
-			ASSERT(board2[25] == BKING);
+				board[a - 1] == EMPTY && 
+				board[a - 2] == EMPTY && 
+				board[a - 3] == EMPTY) {
+			ASSERT(board[21] == BROOK);
+			ASSERT(board[25] == BKING);
 			n_moves++;
 		}
 	}
@@ -345,18 +345,18 @@ static int king_mobility(int a) {
 // Aassume a bishop, rook, or queen is located at addr
 static int slide_mobility(int a, DIRECTION d) {
 	ASSERT(on_board(a));
-	ASSERT(		board2[a] == WQUEEN || 
-			board2[a] == BQUEEN || 
-			board2[a] == WBISHOP || 
-			board2[a] == BBISHOP || 
-			board2[a] == WROOK || 
-			board2[a] == BROOK);
+	ASSERT(		board[a] == WQUEEN || 
+			board[a] == BQUEEN || 
+			board[a] == WBISHOP || 
+			board[a] == BBISHOP || 
+			board[a] == WROOK || 
+			board[a] == BROOK);
 
-	COLOR c = (CMASK & board2[a]) ^ 1u;
+	COLOR c = (CMASK & board[a]) ^ 1u;
 	int n_moves = 0;
 	int off = d;
 	while (1) {
-		PIECE p = board2[a + off];
+		PIECE p = board[a + off];
 		if (p == OFF_BOARD) {
 			break;
 		} else if (p == EMPTY) {
@@ -374,7 +374,7 @@ static int slide_mobility(int a, DIRECTION d) {
 
 // calculate number of pseudo legal moves for a bishop at address a
 static int bishop_mobility(int a) {
-	ASSERT(board2[a] == WBISHOP || board2[a] == BBISHOP);
+	ASSERT(board[a] == WBISHOP || board[a] == BBISHOP);
 	int n_moves = 0;
 	n_moves += slide_mobility(a, UR);
 	n_moves += slide_mobility(a, UL);
@@ -385,7 +385,7 @@ static int bishop_mobility(int a) {
 
 // calculate number of pseudo legal moves for a rook at address a
 static int rook_mobility(int a) {
-	ASSERT(board2[a] == WROOK || board2[a] == BROOK);
+	ASSERT(board[a] == WROOK || board[a] == BROOK);
 	int n_moves = 0;
 	n_moves += slide_mobility(a, U);
 	n_moves += slide_mobility(a, D);
@@ -396,7 +396,7 @@ static int rook_mobility(int a) {
 
 // calculate number of pseudo legal moves for a queen at address a
 static int queen_mobility(int a) {
-	ASSERT(board2[a] == WQUEEN || board2[a] == BQUEEN);
+	ASSERT(board[a] == WQUEEN || board[a] == BQUEEN);
 	int n_moves = 0;
 	n_moves += slide_mobility(a, UR);
 	n_moves += slide_mobility(a, UL);
@@ -416,7 +416,7 @@ static int mobility(void) {
 	int bm = 0;	// black mobility
 
 	for (int addr = 21; addr <= 98; addr++) {
-		PIECE p = board2[addr];
+		PIECE p = board[addr];
 		switch (p) {
 			case WPAWN:
 				wm += wp_mobility(addr);
@@ -538,7 +538,7 @@ static int piece_square_eval(void) {
 	int eg_score = 0;
 
 	for (int addr = 21; addr <= 98; addr++) {
-		PIECE p = board2[addr];
+		PIECE p = board[addr];
 		if (p <= OFF_BOARD)
 			continue;
 		game_phase += GAME_PHASE_INC[p - WPAWN];

--- a/src/move_gen.c
+++ b/src/move_gen.c
@@ -644,9 +644,35 @@ static int gen_queen_moves(Move *ml, int a) {
 
 // Sort the first mi entries in Move list ml by most valuable victim
 // then by least valuable attacker
-static void mvv_lva_quicksort(Move *ml, int mi) {
+static void mvv_lva(Move *ml, int mi) {
 	ASSERT(ml);
+	/*
+	int test_i = 1;
+	int compare_i = 0;
+	while (test_i < mi) {
+		PIECE curr_victim = ml[test_i].cap_piece;
+		PIECE curr_attacker = board2[ml[test_i].mv.sa];
+		PIECE compare_victim = ml[compare_i].cap_piece;
+		PIECE compare_attacker = board2[ml[compare_i].mv.sa];
 
+		// find swap index
+		while (curr_victim > compare_victim || (curr_victim == compare_victim && curr_attacker < compare_attacker)) {
+			if (--compare_i < 0)
+				break;
+			compare_victim = ml[compare_i].cap_piece;
+			compare_attacker = board2[ml[compare_i].mv.sa];
+		}
+
+		ASSERT(compare_i < test_i && compare_i >= -1);
+		// ordering is incorrect
+		if (compare_i < test_i - 1) {
+			Move temp_move = ml[test_i];
+			memmove(ml + compare_i + 2, ml + compare_i + 1, sizeof(Move) * (test_i - (compare_i + 1)));
+			ml[compare_i + 1] = temp_move;
+			}
+			compare_i = test_i++;
+			}
+			*/
 	if (mi <= 1) return;
 
 	int pivot = 0;
@@ -663,34 +689,30 @@ static void mvv_lva_quicksort(Move *ml, int mi) {
 			ml[pivot] = ml[pivot + 1];
 			ml[pivot + 1] = t;
 			pivot++;
-		// swap right if rear_swap != pivot + 1
+			// swap right if rear_swap != pivot + 1
 		} else if (pivot + 1 < rear_swap) {
 			Move t = ml[pivot + 1];
 			ml[pivot + 1] = ml[rear_swap];
 			ml[rear_swap] = t;
 			rear_swap--;
-		// all elements have been checked
+			// all elements have been checked
 		} else {
 			break;
 		}
 	}
 
 	// sort front
-	mvv_lva_quicksort(ml, pivot);
+	mvv_lva(ml, pivot);
 	// sort back if pivot is a capture piece
 	// don't care about order of non captures right now
 	if (ml[pivot].cap_piece >= WPAWN) 
-		mvv_lva_quicksort(ml + pivot + 1, mi - pivot - 1);
-
+		mvv_lva(ml + pivot + 1, mi - pivot - 1);
 }
 
-// generate legal moves in a position
-// caller is responsible for ml memory
-// assume ml is large enough
-// above assumptions are true for all move gen helper functions
-//
-// order of generated move is not always the same because
-// adding and removing pieces changes the move gen order
+// Generate legal moves in a position
+// Caller is responsible for ml memory
+// Assume ml is large enough
+// Above assumptions are true for all move gen helper functions
 int gen_moves(Move *ml) {
 	ASSERT(ml);
 	ASSERT(side_to_move == WHITE || side_to_move == BLACK);
@@ -732,17 +754,7 @@ int gen_moves(Move *ml) {
 		}
 	}
 
-	// place a non capture at front of list to be pivot in quicksort
-	for (int i = 0; i < mi; i++) {
-		if (ml[i].cap_piece < WPAWN) {
-			Move t = ml[0];
-			ml[0] = ml[i];
-			ml[i] = t;
-			break;
-		}
-	}
-
-	mvv_lva_quicksort(ml, mi);
+	mvv_lva(ml, mi);
 	return mi;
 }
 

--- a/src/move_gen.c
+++ b/src/move_gen.c
@@ -13,25 +13,25 @@ int is_square_attacked(int addr, COLOR c) {
 	ASSERT(c == WHITE || c == BLACK);
 
 	if (c == WHITE) {
-		if (board2[addr + 9] == WPAWN || board2[addr + 11] == WPAWN)
+		if (board[addr + 9] == WPAWN || board[addr + 11] == WPAWN)
 			return 1;
-		if (		board2[addr - 21] == WKNIGHT || 
-				board2[addr - 19] == WKNIGHT ||
-				board2[addr - 12] == WKNIGHT || 
-				board2[addr -  8] == WKNIGHT ||
-				board2[addr + 21] == WKNIGHT || 
-				board2[addr + 19] == WKNIGHT ||
-				board2[addr + 12] == WKNIGHT || 
-				board2[addr +  8] == WKNIGHT)
+		if (		board[addr - 21] == WKNIGHT || 
+				board[addr - 19] == WKNIGHT ||
+				board[addr - 12] == WKNIGHT || 
+				board[addr -  8] == WKNIGHT ||
+				board[addr + 21] == WKNIGHT || 
+				board[addr + 19] == WKNIGHT ||
+				board[addr + 12] == WKNIGHT || 
+				board[addr +  8] == WKNIGHT)
 			return 1;
-		if (		board2[addr - 11] == WKING || 
-				board2[addr - 10] == WKING || 
-				board2[addr - 9] == WKING || 
-				board2[addr - 1] == WKING || 
-				board2[addr + 1] == WKING ||
-				board2[addr + 9] == WKING ||
-				board2[addr + 10] == WKING ||
-				board2[addr + 11] == WKING)
+		if (		board[addr - 11] == WKING || 
+				board[addr - 10] == WKING || 
+				board[addr - 9] == WKING || 
+				board[addr - 1] == WKING || 
+				board[addr + 1] == WKING ||
+				board[addr + 9] == WKING ||
+				board[addr + 10] == WKING ||
+				board[addr + 11] == WKING)
 			return 1;
 
 		// sliding checks
@@ -40,7 +40,7 @@ int is_square_attacked(int addr, COLOR c) {
 		int c_addr = addr + dir;
 		// up
 		while (1) {
-			p = board2[c_addr];
+			p = board[c_addr];
 			if (p == WQUEEN || p == WROOK)
 				return 1;
 			if (p == EMPTY)
@@ -52,7 +52,7 @@ int is_square_attacked(int addr, COLOR c) {
 		dir = 10;
 		c_addr = addr + dir;
 		while (1) {
-			p = board2[c_addr];
+			p = board[c_addr];
 			if (p == WQUEEN || p == WROOK)
 				return 1;
 			if (p == EMPTY)
@@ -64,7 +64,7 @@ int is_square_attacked(int addr, COLOR c) {
 		dir = -1;
 		c_addr = addr + dir;
 		while (1) {
-			p = board2[c_addr];
+			p = board[c_addr];
 			if (p == WQUEEN || p == WROOK)
 				return 1;
 			if (p == EMPTY)
@@ -76,7 +76,7 @@ int is_square_attacked(int addr, COLOR c) {
 		dir = 1;
 		c_addr = addr + dir;
 		while (1) {
-			p = board2[c_addr];
+			p = board[c_addr];
 			if (p == WQUEEN || p == WROOK)
 				return 1;
 			if (p == EMPTY)
@@ -88,7 +88,7 @@ int is_square_attacked(int addr, COLOR c) {
 		dir = -11;
 		c_addr = addr + dir;
 		while (1) {
-			p = board2[c_addr];
+			p = board[c_addr];
 			if (p == WQUEEN || p == WBISHOP)
 				return 1;
 			if (p == EMPTY)
@@ -100,7 +100,7 @@ int is_square_attacked(int addr, COLOR c) {
 		dir = -9;
 		c_addr = addr + dir;
 		while (1) {
-			p = board2[c_addr];
+			p = board[c_addr];
 			if (p == WQUEEN || p == WBISHOP)
 				return 1;
 			if (p == EMPTY)
@@ -112,7 +112,7 @@ int is_square_attacked(int addr, COLOR c) {
 		dir = 9;
 		c_addr = addr + dir;
 		while (1) {
-			p = board2[c_addr];
+			p = board[c_addr];
 			if (p == WQUEEN || p == WBISHOP)
 				return 1;
 			if (p == EMPTY)
@@ -124,7 +124,7 @@ int is_square_attacked(int addr, COLOR c) {
 		dir = 11;
 		c_addr = addr + dir;
 		while (1) {
-			p = board2[c_addr];
+			p = board[c_addr];
 			if (p == WQUEEN || p == WBISHOP)
 				return 1;
 			if (p == EMPTY)
@@ -133,25 +133,25 @@ int is_square_attacked(int addr, COLOR c) {
 				break;
 		}
 	} else {
-		if (board2[addr - 9] == BPAWN || board2[addr - 11] == BPAWN)
+		if (board[addr - 9] == BPAWN || board[addr - 11] == BPAWN)
 			return 1;
-		if (		board2[addr - 21] == BKNIGHT || 
-				board2[addr - 19] == BKNIGHT ||
-				board2[addr - 12] == BKNIGHT || 
-				board2[addr -  8] == BKNIGHT ||
-				board2[addr + 21] == BKNIGHT || 
-				board2[addr + 19] == BKNIGHT ||
-				board2[addr + 12] == BKNIGHT || 
-				board2[addr +  8] == BKNIGHT)
+		if (		board[addr - 21] == BKNIGHT || 
+				board[addr - 19] == BKNIGHT ||
+				board[addr - 12] == BKNIGHT || 
+				board[addr -  8] == BKNIGHT ||
+				board[addr + 21] == BKNIGHT || 
+				board[addr + 19] == BKNIGHT ||
+				board[addr + 12] == BKNIGHT || 
+				board[addr +  8] == BKNIGHT)
 			return 1;
-		if (		board2[addr - 11] == BKING || 
-				board2[addr - 10] == BKING || 
-				board2[addr - 9] == BKING || 
-				board2[addr - 1] == BKING || 
-				board2[addr + 1] == BKING ||
-				board2[addr + 9] == BKING ||
-				board2[addr + 10] == BKING ||
-				board2[addr + 11] == BKING)
+		if (		board[addr - 11] == BKING || 
+				board[addr - 10] == BKING || 
+				board[addr - 9] == BKING || 
+				board[addr - 1] == BKING || 
+				board[addr + 1] == BKING ||
+				board[addr + 9] == BKING ||
+				board[addr + 10] == BKING ||
+				board[addr + 11] == BKING)
 			return 1;
 
 		// sliding checks
@@ -160,7 +160,7 @@ int is_square_attacked(int addr, COLOR c) {
 		int c_addr = addr + dir;
 		// up
 		while (1) {
-			p = board2[c_addr];
+			p = board[c_addr];
 			if (p == BQUEEN || p == BROOK)
 				return 1;
 			if (p == EMPTY)
@@ -172,7 +172,7 @@ int is_square_attacked(int addr, COLOR c) {
 		dir = 10;
 		c_addr = addr + dir;
 		while (1) {
-			p = board2[c_addr];
+			p = board[c_addr];
 			if (p == BQUEEN || p == BROOK)
 				return 1;
 			if (p == EMPTY)
@@ -184,7 +184,7 @@ int is_square_attacked(int addr, COLOR c) {
 		dir = -1;
 		c_addr = addr + dir;
 		while (1) {
-			p = board2[c_addr];
+			p = board[c_addr];
 			if (p == BQUEEN || p == BROOK)
 				return 1;
 			if (p == EMPTY)
@@ -196,7 +196,7 @@ int is_square_attacked(int addr, COLOR c) {
 		dir = 1;
 		c_addr = addr + dir;
 		while (1) {
-			p = board2[c_addr];
+			p = board[c_addr];
 			if (p == BQUEEN || p == BROOK)
 				return 1;
 			if (p == EMPTY)
@@ -208,7 +208,7 @@ int is_square_attacked(int addr, COLOR c) {
 		dir = -11;
 		c_addr = addr + dir;
 		while (1) {
-			p = board2[c_addr];
+			p = board[c_addr];
 			if (p == BQUEEN || p == BBISHOP)
 				return 1;
 			if (p == EMPTY)
@@ -220,7 +220,7 @@ int is_square_attacked(int addr, COLOR c) {
 		dir = -9;
 		c_addr = addr + dir;
 		while (1) {
-			p = board2[c_addr];
+			p = board[c_addr];
 			if (p == BQUEEN || p == BBISHOP)
 				return 1;
 			if (p == EMPTY)
@@ -232,7 +232,7 @@ int is_square_attacked(int addr, COLOR c) {
 		dir = 9;
 		c_addr = addr + dir;
 		while (1) {
-			p = board2[c_addr];
+			p = board[c_addr];
 			if (p == BQUEEN || p == BBISHOP)
 				return 1;
 			if (p == EMPTY)
@@ -244,7 +244,7 @@ int is_square_attacked(int addr, COLOR c) {
 		dir = 11;
 		c_addr = addr + dir;
 		while (1) {
-			p = board2[c_addr];
+			p = board[c_addr];
 			if (p == BQUEEN || p == BBISHOP)
 				return 1;
 			if (p == EMPTY)
@@ -266,46 +266,46 @@ int is_square_attacked(int addr, COLOR c) {
 int init_move(Move *move, int sa, int ta) {
 	ASSERT(move);
 	ASSERT(on_board(sa) && on_board(ta));
-	ASSERT(check_color(board2[sa], side_to_move));
-	ASSERT(!check_color(board2[ta], side_to_move));
+	ASSERT(check_color(board[sa], side_to_move));
+	ASSERT(!check_color(board[ta], side_to_move));
 
-	move->cap_piece = board2[ta];
+	move->cap_piece = board[ta];
 	int cap_addr = ta;
 	// handle en passant capture
 	if (ta == ep_addr) {
-		if (board2[sa] == WPAWN) {
-			ASSERT(board2[ta + 10] == BPAWN);
+		if (board[sa] == WPAWN) {
+			ASSERT(board[ta + 10] == BPAWN);
 			move->cap_piece = BPAWN;
 			cap_addr = ta + 10;
 		}
-		else if (board2[sa] == BPAWN) {
-			ASSERT(board2[ta - 10] == WPAWN);
+		else if (board[sa] == BPAWN) {
+			ASSERT(board[ta - 10] == WPAWN);
 			move->cap_piece = WPAWN;
 			cap_addr = ta - 10;
 		}
 	}
 
 	// check for king in check through pseudo make move
-	board2[cap_addr] = EMPTY;
-	PIECE start_piece = board2[sa];
-	board2[sa] = EMPTY;
-	board2[ta] = start_piece;
+	board[cap_addr] = EMPTY;
+	PIECE start_piece = board[sa];
+	board[sa] = EMPTY;
+	board[ta] = start_piece;
 	int ka;
 	int illegal = 0;
 
 	if (side_to_move == WHITE) {
-		ka = wking_addr;
+		ka = piece_addr[WKING][0];
 		if (ka == sa) ka = ta;
 		if (is_square_attacked(ka, BLACK)) illegal = 1;
 	} else {
-		ka = bking_addr;
+		ka = piece_addr[BKING][0];
 		if (ka == sa) ka = ta;
 		if (is_square_attacked(ka, WHITE)) illegal = 1;
 	}
 
-	board2[ta] = EMPTY;
-	board2[cap_addr] = move->cap_piece;
-	board2[sa] = start_piece;
+	board[ta] = EMPTY;
+	board[cap_addr] = move->cap_piece;
+	board[sa] = start_piece;
 	if (illegal) return 0;
 
 	move->mv.sa = sa;
@@ -331,10 +331,10 @@ int init_move(Move *move, int sa, int ta) {
 // accordingly. This function will ALWAYS generate 4 or 0 moves.
 static int gen_promos(Move *ml, int sa, int ta) {
 	ASSERT(ml);
-	ASSERT(board2[sa] != EMPTY && board2[sa] != OFF_BOARD);
+	ASSERT(board[sa] != EMPTY && board[sa] != OFF_BOARD);
 
 	int mi = 0;
-	if (check_color(board2[sa], WHITE)) {
+	if (check_color(board[sa], WHITE)) {
 		if (!init_move(ml + mi, sa, ta))
 			return 0;
 		mi++;
@@ -361,84 +361,98 @@ static int gen_promos(Move *ml, int sa, int ta) {
 	return mi;
 }
 
-// generate pseudo legal moves for a black pawn at address a
+// generate pseudo legal black pawn moves
 // return number of moves generated
-static int gen_bp_moves(Move *ml, int a) {
+static int gen_bp_moves(Move *ml) {
 	ASSERT(ml);
 	ASSERT(side_to_move == BLACK);
-	ASSERT(check_color(board2[a], side_to_move));
-	ASSERT(addr_to_rank(a) <= 7);
-	ASSERT(on_board(a + 10));
 
 	int mi = 0;
-	// advance
-	if (board2[a + 10] == EMPTY) {
-		if (addr_to_rank(a) == 2) {
-			mi += gen_promos(ml + mi, a, a + 10);
-		} else {
-			mi += init_move(ml + mi, a, a + 10);
-			if (addr_to_rank(a) == 7 && board2[a + 20] == EMPTY) {
-				mi += init_move(ml + mi, a, a + 20);
+	int mc = material_counts[BPAWN];
+	int* pa_arr = piece_addr[BPAWN];
+
+	for (int i = 0; i < mc; i++) {
+		int a = pa_arr[i];
+
+		ASSERT(check_color(board[a], side_to_move));
+		ASSERT(addr_to_rank(a) <= 7);
+		ASSERT(on_board(a + 10));
+
+		// advance
+		if (board[a + 10] == EMPTY) {
+			if (addr_to_rank(a) == 2) {
+				mi += gen_promos(ml + mi, a, a + 10);
+			} else {
+				mi += init_move(ml + mi, a, a + 10);
+				if (addr_to_rank(a) == 7 && board[a + 20] == EMPTY) {
+					mi += init_move(ml + mi, a, a + 20);
+				}
 			}
 		}
-	}
-	// captures
-	PIECE tp = board2[a + 9];
-	if (check_color(tp, WHITE) || ep_addr == a + 9) {
-		if (addr_to_rank(a) == 2) {
-			mi += gen_promos(ml + mi, a, a + 9);
-		} else {
-			mi += init_move(ml + mi, a, a + 9);
+		// captures
+		PIECE tp = board[a + 9];
+		if (check_color(tp, WHITE) || ep_addr == a + 9) {
+			if (addr_to_rank(a) == 2) {
+				mi += gen_promos(ml + mi, a, a + 9);
+			} else {
+				mi += init_move(ml + mi, a, a + 9);
+			}
 		}
-	}
-	tp = board2[a + 11];
-	if (check_color(tp, WHITE) || ep_addr == a + 11) {
-		if (addr_to_rank(a) == 2) {
-			mi += gen_promos(ml + mi, a, a + 11);
-		} else {
-			mi += init_move(ml + mi, a, a + 11);
+		tp = board[a + 11];
+		if (check_color(tp, WHITE) || ep_addr == a + 11) {
+			if (addr_to_rank(a) == 2) {
+				mi += gen_promos(ml + mi, a, a + 11);
+			} else {
+				mi += init_move(ml + mi, a, a + 11);
+			}
 		}
 	}
 	return mi;
 }
 
-// generate pseudo legal moves for a white pawn at address a 
+// generate pseudo legal white pawn moves 
 // return number of moves generated
-static int gen_wp_moves(Move *ml, int a) {
+static int gen_wp_moves(Move *ml) {
 	ASSERT(ml);
 	ASSERT(side_to_move == WHITE);
-	ASSERT(check_color(board2[a], side_to_move));
-	ASSERT(addr_to_rank(a) <= 7);
-	ASSERT(on_board(a - 10));
 
 	int mi = 0;
+	int mc = material_counts[WPAWN];
+	int* pa_arr = piece_addr[WPAWN];
 
-	// advance
-	if (board2[a - 10] == EMPTY) {
-		if (addr_to_rank(a) == 7) {
-			mi += gen_promos(ml + mi, a, a - 10);
-		} else {
-			mi += init_move(ml + mi, a, a - 10);
-			if (addr_to_rank(a) == 2 && board2[a - 20] == EMPTY) {
-				mi += init_move(ml + mi, a, a - 20);
+	for (int i = 0; i < mc; i++) {
+		int a = pa_arr[i];
+		ASSERT(check_color(board[a], side_to_move));
+		ASSERT(addr_to_rank(a) <= 7);
+		ASSERT(on_board(a - 10));
+
+		// advance
+		if (board[a - 10] == EMPTY) {
+			if (addr_to_rank(a) == 7) {
+				mi += gen_promos(ml + mi, a, a - 10);
+			} else {
+				mi += init_move(ml + mi, a, a - 10);
+				if (addr_to_rank(a) == 2 && board[a - 20] == EMPTY) {
+					mi += init_move(ml + mi, a, a - 20);
+				}
 			}
 		}
-	}
-	// captures
-	PIECE tp = board2[a - 9];
-	if (check_color(tp, BLACK) || ep_addr == a - 9) {
-		if (addr_to_rank(a) == 7) {
-			mi += gen_promos(ml + mi, a, a - 9);
-		} else {
-			mi += init_move(ml + mi, a, a - 9);
+		// captures
+		PIECE tp = board[a - 9];
+		if (check_color(tp, BLACK) || ep_addr == a - 9) {
+			if (addr_to_rank(a) == 7) {
+				mi += gen_promos(ml + mi, a, a - 9);
+			} else {
+				mi += init_move(ml + mi, a, a - 9);
+			}
 		}
-	}
-	tp = board2[a - 11];
-	if (check_color(tp, BLACK) || ep_addr == a - 11) {
-		if (addr_to_rank(a) == 7) {
-			mi += gen_promos(ml + mi, a, a - 11);
-		} else {
-			mi += init_move(ml + mi, a, a - 11);
+		tp = board[a - 11];
+		if (check_color(tp, BLACK) || ep_addr == a - 11) {
+			if (addr_to_rank(a) == 7) {
+				mi += gen_promos(ml + mi, a, a - 11);
+			} else {
+				mi += init_move(ml + mi, a, a - 11);
+			}
 		}
 	}
 	return mi;
@@ -450,109 +464,128 @@ static int gen_wp_moves(Move *ml, int a) {
 //
 // Target is valid if it is empty or not color c
 static int is_valid_target(int ta, COLOR c) {
-	PIECE p = board2[ta];
+	PIECE p = board[ta];
 	return (p != OFF_BOARD) && (!check_color(p, c) || p == EMPTY);
 }
 
-// generate pseudo legal moves for knight at address a
+// generate pseudo legal knight moves
 // return number of moves generated
 // Assume ml is large enough.
 // Caller is responsible for ml memory.
-static int gen_knight_moves(Move *ml, int a) {
+static int gen_knight_moves(Move *ml) {
 	ASSERT(ml);
 	ASSERT(side_to_move == WHITE || side_to_move == BLACK);
-	ASSERT(check_color(board2[a], side_to_move));
 
 	int mi = 0;
 	COLOR c = side_to_move;
+	PIECE p = WKNIGHT | c;
+	int mc = material_counts[p];
+	int* pa_arr = piece_addr[p];
 
-	if (is_valid_target(a - 21, c))
-		mi += init_move(ml + mi, a, a - 21);
-	if (is_valid_target(a - 19, c))
-		mi += init_move(ml + mi, a, a - 19);
-	if (is_valid_target(a - 12, c))
-		mi += init_move(ml + mi, a, a - 12);
-	if (is_valid_target(a - 8, c))
-		mi += init_move(ml + mi, a, a - 8);
-	if (is_valid_target(a + 21, c))
-		mi += init_move(ml + mi, a, a + 21);
-	if (is_valid_target(a + 19, c))
-		mi += init_move(ml + mi, a, a + 19);
-	if (is_valid_target(a + 12, c))
-		mi += init_move(ml + mi, a, a + 12);
-	if (is_valid_target(a + 8, c))
-		mi += init_move(ml + mi, a, a + 8);
+	for (int i = 0; i < mc; i++) {
+		int a = pa_arr[i];
+		ASSERT(check_color(board[a], side_to_move));
+		ASSERT(on_board(a));
+		ASSERT(board[a] == WKNIGHT || board[a] == BKNIGHT);
+
+		if (is_valid_target(a - 21, c))
+			mi += init_move(ml + mi, a, a - 21);
+		if (is_valid_target(a - 19, c))
+			mi += init_move(ml + mi, a, a - 19);
+		if (is_valid_target(a - 12, c))
+			mi += init_move(ml + mi, a, a - 12);
+		if (is_valid_target(a - 8, c))
+			mi += init_move(ml + mi, a, a - 8);
+		if (is_valid_target(a + 21, c))
+			mi += init_move(ml + mi, a, a + 21);
+		if (is_valid_target(a + 19, c))
+			mi += init_move(ml + mi, a, a + 19);
+		if (is_valid_target(a + 12, c))
+			mi += init_move(ml + mi, a, a + 12);
+		if (is_valid_target(a + 8, c))
+			mi += init_move(ml + mi, a, a + 8);
+	}
 	return mi;
 }
 
-// generate pseudo legal moves for a king at address a
+// generate pseudo legal king moves
 // return number of moves generated
 // Assume ml is large enough.
 // Caller is responsible for ml memory.
-static int gen_king_moves(Move *ml, int a) {
+static int gen_king_moves(Move *ml) {
 	ASSERT(ml);
 	ASSERT(side_to_move == WHITE || side_to_move == BLACK);
-	ASSERT(check_color(board2[a], side_to_move));
 
 	int mi = 0;
 	COLOR c = side_to_move;
+	PIECE p = WKING | c;
+	int mc = material_counts[p];
+	int* pa_arr = piece_addr[p];
 
-	if (is_valid_target(a - 11, c))
-		mi += init_move(ml + mi, a, a - 11);
-	if (is_valid_target(a - 10, c))
-		mi += init_move(ml + mi, a, a - 10);
-	if (is_valid_target(a - 9, c))
-		mi += init_move(ml + mi, a, a - 9);
-	if (is_valid_target(a - 1, c))
-		mi += init_move(ml + mi, a, a - 1);
-	if (is_valid_target(a + 1, c))
-		mi += init_move(ml + mi, a, a + 1);
-	if (is_valid_target(a + 9, c))
-		mi += init_move(ml + mi, a, a + 9);
-	if (is_valid_target(a + 10, c))
-		mi += init_move(ml + mi, a, a + 10);
-	if (is_valid_target(a + 11, c))
-		mi += init_move(ml + mi, a, a + 11);
+	for (int i = 0; i < mc; i++) {
+		int a = pa_arr[i];
+		ASSERT(check_color(board[a], side_to_move));
+		ASSERT(on_board(a));
+		ASSERT(board[a] == WKING || board[a] == BKING);
 
-	if (c == WHITE) {
-		if (		castle_rights & K_CASTLE && 
-				board2[a + 1] == EMPTY && 
-				board2[a + 2] == EMPTY && 
-				!is_square_attacked(a, BLACK) && 
-				!is_square_attacked(a + 1, BLACK)) {
-			ASSERT(board2[98] == WROOK);
-			ASSERT(board2[95] == WKING);
-			mi += init_move(ml + mi, a, a + 2);
-		}
-		if (		castle_rights & Q_CASTLE && 
-				board2[a - 1] == EMPTY && 
-				board2[a - 2] == EMPTY && 
-				board2[a - 3] == EMPTY &&
-				!is_square_attacked(a, BLACK) && 
-				!is_square_attacked(a - 1, BLACK)) {
-			ASSERT(board2[91] == WROOK);
-			ASSERT(board2[95] == WKING);
-			mi += init_move(ml + mi, a, a - 2);
-		}
-	} else {
-		if (		castle_rights & k_CASTLE && 
-				board2[a + 1] == EMPTY && 
-				board2[a + 2] == EMPTY && 
-				!is_square_attacked(a, WHITE) && 
-				!is_square_attacked(a + 1, WHITE)) {
-			ASSERT(board2[28] == BROOK);
-			ASSERT(board2[25] == BKING);
-			mi += init_move(ml + mi, a, a + 2);
-		}
-		if (		castle_rights & q_CASTLE && 
-				board2[a - 1] == EMPTY && 
-				board2[a - 2] == EMPTY && 
-				board2[a - 3] == EMPTY &&
-				!is_square_attacked(a, WHITE) && 
-				!is_square_attacked(a - 1, WHITE)) {
-			ASSERT(board2[21] == BROOK);
-			ASSERT(board2[25] == BKING);
-			mi += init_move(ml + mi, a, a - 2);
+
+		if (is_valid_target(a - 11, c))
+			mi += init_move(ml + mi, a, a - 11);
+		if (is_valid_target(a - 10, c))
+			mi += init_move(ml + mi, a, a - 10);
+		if (is_valid_target(a - 9, c))
+			mi += init_move(ml + mi, a, a - 9);
+		if (is_valid_target(a - 1, c))
+			mi += init_move(ml + mi, a, a - 1);
+		if (is_valid_target(a + 1, c))
+			mi += init_move(ml + mi, a, a + 1);
+		if (is_valid_target(a + 9, c))
+			mi += init_move(ml + mi, a, a + 9);
+		if (is_valid_target(a + 10, c))
+			mi += init_move(ml + mi, a, a + 10);
+		if (is_valid_target(a + 11, c))
+			mi += init_move(ml + mi, a, a + 11);
+
+		if (c == WHITE) {
+			if (		castle_rights & K_CASTLE && 
+					board[a + 1] == EMPTY && 
+					board[a + 2] == EMPTY && 
+					!is_square_attacked(a, BLACK) && 
+					!is_square_attacked(a + 1, BLACK)) {
+				ASSERT(board[98] == WROOK);
+				ASSERT(board[95] == WKING);
+				mi += init_move(ml + mi, a, a + 2);
+			}
+			if (		castle_rights & Q_CASTLE && 
+					board[a - 1] == EMPTY && 
+					board[a - 2] == EMPTY && 
+					board[a - 3] == EMPTY &&
+					!is_square_attacked(a, BLACK) && 
+					!is_square_attacked(a - 1, BLACK)) {
+				ASSERT(board[91] == WROOK);
+				ASSERT(board[95] == WKING);
+				mi += init_move(ml + mi, a, a - 2);
+			}
+		} else {
+			if (		castle_rights & k_CASTLE && 
+					board[a + 1] == EMPTY && 
+					board[a + 2] == EMPTY && 
+					!is_square_attacked(a, WHITE) && 
+					!is_square_attacked(a + 1, WHITE)) {
+				ASSERT(board[28] == BROOK);
+				ASSERT(board[25] == BKING);
+				mi += init_move(ml + mi, a, a + 2);
+			}
+			if (		castle_rights & q_CASTLE && 
+					board[a - 1] == EMPTY && 
+					board[a - 2] == EMPTY && 
+					board[a - 3] == EMPTY &&
+					!is_square_attacked(a, WHITE) && 
+					!is_square_attacked(a - 1, WHITE)) {
+				ASSERT(board[21] == BROOK);
+				ASSERT(board[25] == BKING);
+				mi += init_move(ml + mi, a, a - 2);
+			}
 		}
 	}
 	return mi;
@@ -566,21 +599,21 @@ static int gen_king_moves(Move *ml, int a) {
 // Assume move_list is initialized and has enough space
 // Aassume a bishop, rook, or queen is located at addr
 static int gen_slide_move(Move *ml, int a, DIRECTION d) {
-	ASSERT(check_color(board2[a], side_to_move));
+	ASSERT(check_color(board[a], side_to_move));
 	ASSERT(ml);
 	ASSERT(on_board(a));
-	ASSERT(		board2[a] == WQUEEN || 
-			board2[a] == BQUEEN || 
-			board2[a] == WBISHOP || 
-			board2[a] == BBISHOP || 
-			board2[a] == WROOK || 
-			board2[a] == BROOK);
+	ASSERT(		board[a] == WQUEEN || 
+			board[a] == BQUEEN || 
+			board[a] == WBISHOP || 
+			board[a] == BBISHOP || 
+			board[a] == WROOK || 
+			board[a] == BROOK);
 
 	COLOR c = side_to_move ^ 1;
 	int mi = 0;
 	int off = d;
 	while (1) {
-		PIECE p = board2[a + off];
+		PIECE p = board[a + off];
 		if (p == OFF_BOARD) {
 			break;
 		} else if (p == EMPTY) {
@@ -596,110 +629,114 @@ static int gen_slide_move(Move *ml, int a, DIRECTION d) {
 	return mi;
 }
 
-// generate pseudo legal moves for a bishop at address a
+// generate pseudo legal bishop moves
 // return number of moves generated
 // Assume ml is large enough.
 // Caller is responsible for ml memory.
-static int gen_bishop_moves(Move *ml, int a) {
+static int gen_bishop_moves(Move *ml) {
 	ASSERT(ml);
+
 	int mi = 0;
-	mi += gen_slide_move(ml + mi, a, UR);
-	mi += gen_slide_move(ml + mi, a, UL);
-	mi += gen_slide_move(ml + mi, a, DR);
-	mi += gen_slide_move(ml + mi, a, DL);
+	PIECE p = WBISHOP | side_to_move;
+	int mc = material_counts[p];
+	int* pa_arr = piece_addr[p];
+
+	for (int i = 0; i < mc; i++) {
+		int a = pa_arr[i];
+		ASSERT(on_board(a));
+		ASSERT(board[a] == WBISHOP || board[a] == BBISHOP);
+
+		mi += gen_slide_move(ml + mi, a, UR);
+		mi += gen_slide_move(ml + mi, a, UL);
+		mi += gen_slide_move(ml + mi, a, DR);
+		mi += gen_slide_move(ml + mi, a, DL);
+	}
 	return mi;
 }
 
-// generate pseudo legal moves for a rook at address a
+// generate pseudo legal rook moves
 // return number of moves generated
 // Assume ml is large enough.
 // Caller is responsible for ml memory.
-static int gen_rook_moves(Move *ml, int a) {
+static int gen_rook_moves(Move *ml) {
 	ASSERT(ml);
+
 	int mi = 0;
-	mi += gen_slide_move(ml + mi, a, U);
-	mi += gen_slide_move(ml + mi, a, D);
-	mi += gen_slide_move(ml + mi, a, L);
-	mi += gen_slide_move(ml + mi, a, R);
+	PIECE p = WROOK | side_to_move;
+	int mc = material_counts[p];
+	int* pa_arr = piece_addr[p];
+
+	for (int i = 0; i < mc; i++) {
+		int a = pa_arr[i];
+		ASSERT(on_board(a));
+		ASSERT(board[a] == WROOK || board[a] == BROOK);
+
+		mi += gen_slide_move(ml + mi, a, U);
+		mi += gen_slide_move(ml + mi, a, D);
+		mi += gen_slide_move(ml + mi, a, L);
+		mi += gen_slide_move(ml + mi, a, R);
+	}
 	return mi;
 }
 
-// generate pseudo legal moves for a queen at address a
+// generate pseudo legal queen moves
 // return number of moves generated
 // Assume ml is large enough.
 // Caller is responsible for ml memory.
-static int gen_queen_moves(Move *ml, int a) {
+static int gen_queen_moves(Move *ml) {
 	ASSERT(ml);
+
 	int mi = 0;
-	mi += gen_slide_move(ml + mi, a, UR);
-	mi += gen_slide_move(ml + mi, a, UL);
-	mi += gen_slide_move(ml + mi, a, DR);
-	mi += gen_slide_move(ml + mi, a, DL);
-	mi += gen_slide_move(ml + mi, a, U);
-	mi += gen_slide_move(ml + mi, a, D);
-	mi += gen_slide_move(ml + mi, a, L);
-	mi += gen_slide_move(ml + mi, a, R);
+	PIECE p = WQUEEN | side_to_move;
+	int mc = material_counts[p];
+	int* pa_arr = piece_addr[p];
+
+	for (int i = 0; i < mc; i++) {
+		int a = pa_arr[i];
+		ASSERT(on_board(a));
+		ASSERT(board[a] == WQUEEN || board[a] == BQUEEN);
+
+		mi += gen_slide_move(ml + mi, a, UR);
+		mi += gen_slide_move(ml + mi, a, UL);
+		mi += gen_slide_move(ml + mi, a, DR);
+		mi += gen_slide_move(ml + mi, a, DL);
+		mi += gen_slide_move(ml + mi, a, U);
+		mi += gen_slide_move(ml + mi, a, D);
+		mi += gen_slide_move(ml + mi, a, L);
+		mi += gen_slide_move(ml + mi, a, R);
+	}
 	return mi;
 }
 
 // Sort the first mi entries in Move list ml by most valuable victim
 // then by least valuable attacker
+// Quciksort algorithm
 static void mvv_lva(Move *ml, int mi) {
 	ASSERT(ml);
-	/*
-	int test_i = 1;
-	int compare_i = 0;
-	while (test_i < mi) {
-		PIECE curr_victim = ml[test_i].cap_piece;
-		PIECE curr_attacker = board2[ml[test_i].mv.sa];
-		PIECE compare_victim = ml[compare_i].cap_piece;
-		PIECE compare_attacker = board2[ml[compare_i].mv.sa];
-
-		// find swap index
-		while (curr_victim > compare_victim || (curr_victim == compare_victim && curr_attacker < compare_attacker)) {
-			if (--compare_i < 0)
-				break;
-			compare_victim = ml[compare_i].cap_piece;
-			compare_attacker = board2[ml[compare_i].mv.sa];
-		}
-
-		ASSERT(compare_i < test_i && compare_i >= -1);
-		// ordering is incorrect
-		if (compare_i < test_i - 1) {
-			Move temp_move = ml[test_i];
-			memmove(ml + compare_i + 2, ml + compare_i + 1, sizeof(Move) * (test_i - (compare_i + 1)));
-			ml[compare_i + 1] = temp_move;
-			}
-			compare_i = test_i++;
-			}
-			*/
 	if (mi <= 1) return;
 
 	int pivot = 0;
+	PIECE v1 = ml[0].cap_piece;
+	PIECE a1 = board[ml[0].mv.sa];
 	int rear_swap = mi - 1;
 
 	while (pivot < rear_swap) {
-		PIECE v1 = ml[pivot].cap_piece;
 		PIECE v2 = ml[pivot + 1].cap_piece;
-		PIECE a1 = board2[ml[pivot].mv.sa];
-		PIECE a2 = board2[ml[pivot + 1].mv.sa];
+		PIECE a2 = board[ml[pivot + 1].mv.sa];
 		// swap left if pivot + 1 is a greater capture
 		if (v2 > v1 || (v1 == v2 && a2 < a1)) {
-			Move t = ml[pivot];
-			ml[pivot] = ml[pivot + 1];
-			ml[pivot + 1] = t;
 			pivot++;
-			// swap right if rear_swap != pivot + 1
-		} else if (pivot + 1 < rear_swap) {
+		} else {
 			Move t = ml[pivot + 1];
 			ml[pivot + 1] = ml[rear_swap];
 			ml[rear_swap] = t;
 			rear_swap--;
 			// all elements have been checked
-		} else {
-			break;
-		}
+		} 
 	}
+	Move t = ml[0];
+	ml[0] = ml[pivot];
+	ml[pivot] = t;
 
 	// sort front
 	mvv_lva(ml, pivot);
@@ -718,70 +755,94 @@ int gen_moves(Move *ml) {
 	ASSERT(side_to_move == WHITE || side_to_move == BLACK);
 
 	int mi = 0;
-	for (int addr = 21; addr <= 98; addr++) {
-		PIECE p = board2[addr];
-		if (p < WPAWN || !check_color(p, side_to_move))
-			continue;
-		switch (p) {
-			case WPAWN:
-				mi += gen_wp_moves(ml + mi, addr);
-				break;
-			case BPAWN:
-				mi += gen_bp_moves(ml + mi, addr);
-				break;
-			case WKNIGHT:
-			case BKNIGHT:
-				mi += gen_knight_moves(ml + mi, addr);
-				break;
-			case WBISHOP:
-			case BBISHOP:
-				mi += gen_bishop_moves(ml + mi, addr);
-				break;
-			case WROOK:
-			case BROOK:
-				mi += gen_rook_moves(ml + mi, addr);
-				break;
-			case WQUEEN:
-			case BQUEEN:
-				mi += gen_queen_moves(ml + mi, addr);
-				break;
-			case WKING:
-			case BKING:
-				mi += gen_king_moves(ml + mi, addr);
-				break;
-			default:
-				ASSERT(0);
-		}
-	}
+	if (side_to_move == WHITE)
+		mi += gen_wp_moves(ml);
+	else
+		mi += gen_bp_moves(ml);
+	mi += gen_knight_moves(ml + mi);
+	mi += gen_bishop_moves(ml + mi);
+	mi += gen_rook_moves(ml + mi);
+	mi += gen_queen_moves(ml + mi);
+	mi += gen_king_moves(ml + mi);
 
 	mvv_lva(ml, mi);
 	return mi;
 }
 
-// move piece at source address to target address
-// helper function for make_move()
-static void move_piece(int sa, int ta) {
-	ASSERT(on_board(ta));
-	ASSERT(on_board(sa));
-
-	PIECE p = board2[sa];
-	hash_piece(p, sa);
-	board2[ta] = p;
-	board2[sa] = EMPTY;
-	hash_piece(p, ta);
-}
-
-// move piece from source address to target address
-// helper function for unmake_move()
+// Move piece at source address to target address
+// Input a logical true value for hash to perform hashing
+// Input a logical false value for hash to skip hashing
 //
-// same as move_piece except without hashing as
-// unmake_move() handles that itself
-static void unmove_piece(int sa, int ta) {
+// unmake_move() does not need hashing because it
+// copies hash stored in Move to game_hash
+static void move_piece(int sa, int ta, int hash) {
 	ASSERT(on_board(ta));
 	ASSERT(on_board(sa));
-	board2[ta] = board2[sa];
-	board2[sa] = EMPTY;
+
+	PIECE p = board[sa];
+	ASSERT(p >= WPAWN && p<= BKING);
+
+	if (hash) hash_piece(p, sa);
+	board[ta] = p;
+	board[sa] = EMPTY;
+	if (hash) hash_piece(p, ta);
+
+	int* pa_arr = piece_addr[p];
+	int mc = material_counts[p];
+	for (int i = 0; i < mc; i++) {
+		if (pa_arr[i] == sa) {
+			pa_arr[i] = ta;
+			break;
+		}
+		ASSERT(i != mc - 1);
+	}
 }
+
+// Add piece p at address a to all data structures
+// Input a logical true value for hash to perform hashing
+// Input a logical false value for hash to skip hashing
+//
+// unmake_move() does not need hashing because it
+// copies hash stored in Move to game_hash
+static void add_piece(PIECE p, int a, int hash) {
+	ASSERT(on_board(a));
+	ASSERT(board[a] == EMPTY);
+	ASSERT(p >= WPAWN && p <= BKING);
+	ASSERT(material_counts[p] < 10);
+
+	board[a] = p;
+	int mc = material_counts[p]++;
+	piece_addr[p][mc] = a;
+	if (hash) hash_piece(p, a);
+}
+
+// Remove piece at address a from all data structures
+// Input a logical true value for hash to perform hashing
+// Input a logical false value for hash to skip hashing
+//
+// unmake_move() does not need hashing because it
+// copies hash stored in Move to game_hash
+static void remove_piece(int a, int hash) {
+	ASSERT(on_board(a));
+
+	PIECE p = board[a];
+	ASSERT(p >= WPAWN && p <= BKING);
+	ASSERT(material_counts[p] > 0);
+
+	board[a] = EMPTY;
+
+	int mc = material_counts[p]--;
+	int* pa_arr = piece_addr[p];
+	for (int i = 0; i < mc; i++) {
+		if (pa_arr[i] == a) {
+			pa_arr[i] = pa_arr[mc - 1];
+			break;
+		}
+		ASSERT(i != mc - 1);
+	}
+	if (hash) hash_piece(p, a);
+}
+
 
 // Revert board state to previous move using Move used to generate
 // most recent move.
@@ -796,14 +857,11 @@ void unmake_move(Move *move) {
 
 	const int s = move->mv.sa;
 	const int e = move->mv.ta;
-	PIECE ept = board2[e];
-
-	if (ept == WKING) wking_addr = s;
-	else if (ept == BKING) bking_addr = s;
+	PIECE ept = board[e];
 
 	ASSERT(on_board(s));
 	ASSERT(on_board(e));
-	ASSERT(board2[s] == EMPTY);
+	ASSERT(board[s] == EMPTY);
 	ASSERT(ept >= WPAWN && ept <= BKING);
 
 	// ummove piece and handle special cases
@@ -815,40 +873,34 @@ void unmake_move(Move *move) {
 		ASSERT(c == WHITE || c == BLACK);
 		ASSERT(ept > WPAWN || ept <= BQUEEN);
 
-		--material_counts[ept];
-		if (c == WHITE) {
-			board2[e] = WPAWN;
-			++material_counts[WPAWN];
-		} else {
-			board2[e] = BPAWN;
-			++material_counts[BPAWN];
-		}
+		remove_piece(e, 0);
+		if (c == WHITE) add_piece(WPAWN, e, 0);
+		else add_piece(BPAWN, e, 0);
 	} 
 	// undo kingside castle
 	else if ((ept == WKING || ept == BKING) && e == s + 2) {
-		unmove_piece(e - 1, e + 1);
+		move_piece(e - 1, e + 1, 0);
 	}
 	// undo queenside castle
 	else if ((ept == WKING || ept == BKING) && e == s - 2) {
-		unmove_piece(e + 1, e - 2);
+		move_piece(e + 1, e - 2, 0);
 	}
 	// standard move
-	unmove_piece(e, s);
+	move_piece(e, s, 0);
 
 	// uncapture piece (or replace with NONE if no capture occurred)
 	PIECE cap_piece = move->cap_piece;
 	if (cap_piece != EMPTY){
 		ASSERT(cap_piece != OFF_BOARD);
-		++material_counts[cap_piece];
 
 		int cap_addr = e;
 		if (e == ep_addr) {
-			ASSERT(board2[s] == WPAWN || board2[s] == BPAWN);
+			ASSERT(board[s] == WPAWN || board[s] == BPAWN);
 			ASSERT(cap_piece == WPAWN || cap_piece == BPAWN);
 			if (check_color(cap_piece, WHITE)) cap_addr -= 10;
 			else cap_addr += 10;
 		}
-		board2[cap_addr] = cap_piece;
+		add_piece(cap_piece, cap_addr, 0);
 	}
 
 	if (side_to_move == WHITE) {
@@ -872,14 +924,10 @@ void make_move(Move *move) {
 	// start and end squares
 	int s = move->mv.sa;
 	int e = move->mv.ta;
-	PIECE spt = board2[s];
+	PIECE spt = board[s];
 
 	ASSERT(on_board(s));
 	ASSERT(on_board(e));
-
-	// track king square
-	if (spt == WKING) wking_addr = e;
-	else if (spt == BKING) bking_addr = e;
 
 	// capture piece
 	if (move->cap_piece != EMPTY) {
@@ -894,9 +942,7 @@ void make_move(Move *move) {
 			ASSERT((addr_to_rank(cap_addr) == 5 && side_to_move == WHITE) || 
 					(addr_to_rank(cap_addr) == 4 && side_to_move == BLACK));
 		}
-		hash_piece(move->cap_piece, cap_addr);
-		board2[cap_addr] = EMPTY;
-		--material_counts[move->cap_piece];
+		remove_piece(cap_addr, 1);
 	}
 	// move piece in mailbox and handle special cases
 	//
@@ -922,24 +968,18 @@ void make_move(Move *move) {
 				 promo <= BQUEEN &&
 				 check_color(promo, BLACK)));
 
-		move_piece(s, e);
-		// hash out piece because we are promoting
-		hash_piece(spt, e);
-		--material_counts[spt];
-
-		board2[e] = promo;
-		++material_counts[promo];
-		hash_piece(promo, e);
+		remove_piece(s, 1);
+		add_piece(promo, e, 1);
 	} 
 	// white kingside castle
 	else if (spt == WKING && e == s + 2) {
 		ASSERT(castle_rights & K_CASTLE);
-		ASSERT(board2[s + 1] == EMPTY && board2[s + 2] == EMPTY);
+		ASSERT(board[s + 1] == EMPTY && board[s + 2] == EMPTY);
 		ASSERT(s == 95);
-		ASSERT(board2[98] == WROOK);
+		ASSERT(board[98] == WROOK);
 
-		move_piece(e + 1, e - 1);
-		move_piece(s, e);
+		move_piece(e + 1, e - 1, 1);
+		move_piece(s, e, 1);
 
 		hash_castle();
 		castle_rights ^= K_CASTLE;
@@ -949,14 +989,14 @@ void make_move(Move *move) {
 	// white queenside castle
 	else if (spt == WKING && e == s - 2) {
 		ASSERT(castle_rights & Q_CASTLE);
-		ASSERT(board2[s - 1] == EMPTY && 
-				board2[s - 2] == EMPTY && 
-				board2[s - 3] == EMPTY);
+		ASSERT(board[s - 1] == EMPTY && 
+				board[s - 2] == EMPTY && 
+				board[s - 3] == EMPTY);
 		ASSERT(s == 95);
-		ASSERT(board2[91] == WROOK);
+		ASSERT(board[91] == WROOK);
 
-		move_piece(e - 2, e + 1);
-		move_piece(s, e);
+		move_piece(e - 2, e + 1, 1);
+		move_piece(s, e, 1);
 
 		hash_castle();
 		castle_rights ^= Q_CASTLE;
@@ -966,12 +1006,12 @@ void make_move(Move *move) {
 	// black kingside castle
 	else if (spt == BKING && e == s + 2) {
 		ASSERT(castle_rights & k_CASTLE);
-		ASSERT(board2[s + 1] == EMPTY && board2[s + 2] == EMPTY);
+		ASSERT(board[s + 1] == EMPTY && board[s + 2] == EMPTY);
 		ASSERT(s == 25);
-		ASSERT(board2[28] == BROOK);
+		ASSERT(board[28] == BROOK);
 
-		move_piece(e + 1, e - 1);
-		move_piece(s, e);
+		move_piece(e + 1, e - 1, 1);
+		move_piece(s, e, 1);
 
 		hash_castle();
 		castle_rights ^= k_CASTLE;
@@ -981,12 +1021,12 @@ void make_move(Move *move) {
 	// black queenside castle
 	else if (spt == BKING && e == s - 2) {
 		ASSERT(castle_rights & q_CASTLE);
-		ASSERT(board2[s - 1] == EMPTY && board2[s - 2] == EMPTY && board2[s - 3] == EMPTY);
+		ASSERT(board[s - 1] == EMPTY && board[s - 2] == EMPTY && board[s - 3] == EMPTY);
 		ASSERT(s == 25);
-		ASSERT(board2[21] == BROOK);
+		ASSERT(board[21] == BROOK);
 
-		move_piece(e - 2, e + 1);
-		move_piece(s, e);
+		move_piece(e - 2, e + 1, 1);
+		move_piece(s, e, 1);
 
 		hash_castle();
 		castle_rights ^= q_CASTLE;
@@ -995,9 +1035,9 @@ void make_move(Move *move) {
 	}
 	// standard move
 	else {
-		move_piece(s, e);
+		move_piece(s, e, 1);
 	}
-	ASSERT(board2[s] == EMPTY);
+	ASSERT(board[s] == EMPTY);
 
 	// increment fullmove and halfmove if applicable
 	if (side_to_move == BLACK) moves++;

--- a/src/search.c
+++ b/src/search.c
@@ -276,9 +276,9 @@ Search_Result ab_search(AB_Params params) {
 
 	// no moves and king not attacked is stalemate
 	if (!n_moves) {
-		if (side_to_move == WHITE && !is_square_attacked(wking_addr, BLACK)) {
+		if (side_to_move == WHITE && !is_square_attacked(piece_addr[WKING][0], BLACK)) {
 			best_score = 0;
-		} else if (side_to_move == BLACK && !is_square_attacked(bking_addr, WHITE)) {
+		} else if (side_to_move == BLACK && !is_square_attacked(piece_addr[BKING][0], WHITE)) {
 			best_score = 0;
 		}
 	}

--- a/src/search.c
+++ b/src/search.c
@@ -109,7 +109,7 @@ static int quiesce(int alpha, int beta, char is_timed, ULL ms_cutoff) {
 	for (int i = 0; i < n_moves; i++) {
 		// stop once captures are all examined
 		// assume MVV-LVA ordering
-		if (ml[i].cap_piece == EMPTY)
+		if (ml[i].cap_piece < WPAWN)
 			break;
 
 		make_move(ml + i);

--- a/src/testing.c
+++ b/src/testing.c
@@ -56,7 +56,7 @@ static void print_board(void) {
 		printf("   ---------------------------------\n");
 		printf(" %i |", 8 - y);
 		for (int x = 0; x < 8; x++) {
-			printf(" %c |", piece_to_char(board2[(y + 2) * 10 + x + 1]));
+			printf(" %c |", piece_to_char(board[(y + 2) * 10 + x + 1]));
 		}
 		printf("\n");
 	}
@@ -258,4 +258,52 @@ void perft_test(int max_depth) {
 	printf("Total time elapsed: %llu.%llu\n", total_secs, total_milli);
 	printf("Nodes/sec: ~%lli\n", 1000 * (total_nodes / (1000 * total_secs + total_milli)));
 	printf("***********************\n\n");
+}
+
+// Generate some duplicate position and confirm hash is the same
+static void hash_check(void) {
+	load_position(STARTING_FEN);
+	ULL hash = game_hash;
+	make_manual_move("b1c3", 4);
+	make_manual_move("b8c6", 4);
+	make_manual_move("c3b1", 4);
+	make_manual_move("c6b8", 4);
+	if (hash != game_hash) {
+		printf("Hash check failed!\n");
+		return;
+	}
+
+	load_position(STARTING_FEN);
+	make_manual_move("d2d4", 4);
+	make_manual_move("d7d5", 4);
+	make_manual_move("b1c3", 4);
+	make_manual_move("b8c6", 4);
+	make_manual_move("c3d5", 4);
+	make_manual_move("c6d4", 4);
+	make_manual_move("d5c3", 4);
+	make_manual_move("d4c6", 4);
+	make_manual_move("c3b1", 4);
+	make_manual_move("c6b8", 4);
+	hash = game_hash;
+	load_position(STARTING_FEN);
+	make_manual_move("d2d4", 4);
+	make_manual_move("d7d5", 4);
+	make_manual_move("d1d3", 4);
+	make_manual_move("d8d6", 4);
+	make_manual_move("d3f3", 4);
+	make_manual_move("d6f6", 4);
+	make_manual_move("f3d5", 4);
+	make_manual_move("f6d4", 4);
+	make_manual_move("d5f3", 4);
+	make_manual_move("d4f6", 4);
+	make_manual_move("f3d3", 4);
+	make_manual_move("f6d6", 4);
+	make_manual_move("d3d1", 4);
+	make_manual_move("d6d8", 4);
+	if (hash != game_hash) {
+		printf("Hash check failed!\n");
+		return;
+	}
+
+	printf("Hash check passed!\n");
 }


### PR DESCRIPTION
Improved move ordering by create piece address arrays that store the current board addresses of pieces in the game by type. This allows for movelists that can be initialized in order of least valuable attacker which reduces sorting cost of MVV-LVA. It also has the added benefit of providing the exact addresses to init moves from rather than searching each square of the board.

Additionally, hashing checks were added to testing code.